### PR TITLE
removed unmaintaned ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2


### PR DESCRIPTION
### WHAT
Removing ruby 1.9.3 of ruby version list